### PR TITLE
fix: Standardize credential variable names across GitHub Actions work…

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -287,8 +287,8 @@ jobs:
       - name: Run backend smoke tests
         env:
           ENVIRONMENT: dev
-          WC_CONSUMER_KEY: ${{ secrets.WC_CONSUMER_KEY }}
-          WC_CONSUMER_SECRET: ${{ secrets.WC_CONSUMER_SECRET }}
+          API_CONSUMER_KEY: ${{ secrets.API_CONSUMER_KEY }}
+          API_CONSUMER_SECRET: ${{ secrets.API_CONSUMER_SECRET }}
         run: |
           mvn test -Dtest=SimpleCustomerApiTest -Dcucumber.filter.tags="@smoke and @api" -Denv=dev
           
@@ -446,8 +446,8 @@ jobs:
       - name: Run backend regression tests
         env:
           ENVIRONMENT: staging
-          WC_CONSUMER_KEY: ${{ secrets.WC_CONSUMER_KEY }}
-          WC_CONSUMER_SECRET: ${{ secrets.WC_CONSUMER_SECRET }}
+          API_CONSUMER_KEY: ${{ secrets.API_CONSUMER_KEY }}
+          API_CONSUMER_SECRET: ${{ secrets.API_CONSUMER_SECRET }}
         run: |
           mvn test -Dtest=SimpleCustomerApiTest -Dcucumber.filter.tags="@regression and @api" -Denv=staging
           

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -61,8 +61,8 @@ jobs:
         run: |
           mvn test -Dtest=HomepageTestRunner -Dcucumber.filter.tags="@frontend" -Denv=${{ github.event.inputs.environment }}
         env:
-          WC_CONSUMER_KEY: ${{ secrets.WC_CONSUMER_KEY }}
-          WC_CONSUMER_SECRET: ${{ secrets.WC_CONSUMER_SECRET }}
+          API_CONSUMER_KEY: ${{ secrets.API_CONSUMER_KEY }}
+          API_CONSUMER_SECRET: ${{ secrets.API_CONSUMER_SECRET }}
           
       - name: Upload frontend test results
         uses: actions/upload-artifact@v4
@@ -102,8 +102,8 @@ jobs:
         run: |
           mvn test -Dtest=SimpleCustomerApiTest -Denv=${{ github.event.inputs.environment }}
         env:
-          WC_CONSUMER_KEY: ${{ secrets.WC_CONSUMER_KEY }}
-          WC_CONSUMER_SECRET: ${{ secrets.WC_CONSUMER_SECRET }}
+          API_CONSUMER_KEY: ${{ secrets.API_CONSUMER_KEY }}
+          API_CONSUMER_SECRET: ${{ secrets.API_CONSUMER_SECRET }}
           
       - name: Upload backend test results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
…flows

- Update GitHub Actions workflows to use API_CONSUMER_KEY/SECRET instead of WC_CONSUMER_KEY/SECRET
- Ensures consistency with Java framework configuration and documentation
- Fixes credential variable mismatch that would prevent API tests from running in CI/CD
- All credential references now use consistent naming convention:
  * API_CONSUMER_KEY (instead of WC_CONSUMER_KEY)
  * API_CONSUMER_SECRET (instead of WC_CONSUMER_SECRET)

This aligns with:
- Java ConfigManager.java environment variable expectations
- Properties files configuration
- Documentation and shell scripts
- Existing codebase standards